### PR TITLE
fix build on arch linux

### DIFF
--- a/apkg/CONTROL/config.json
+++ b/apkg/CONTROL/config.json
@@ -28,7 +28,6 @@
         "gpg-error",
         "gpgparsemail",
         "gpgrt-config",
-        "gpgscm",
         "gpgsm",
         "gpgsplit",
         "gpgtar",

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ download_and_extract "gnupg" "$GNUPG_VERSION" "https://gnupg.org/ftp/gcrypt/gnup
 echo ""
 echo "Step 2: Building libgpg-error..."
 cd "libgpg-error-${LIBGPG_ERROR_VERSION}"
-./configure --prefix="$PREFIX"
+./configure --prefix="$PREFIX" CFLAGS="-std=gnu99"
 make -j$(nproc)
 make install DESTDIR="${STAGING_DIR}"
 cd ..

--- a/build.sh
+++ b/build.sh
@@ -111,6 +111,7 @@ cd "gnupg-${GNUPG_VERSION}"
     --with-libassuan-prefix="${STAGING_DIR}${PREFIX}" \
     --with-ksba-prefix="${STAGING_DIR}${PREFIX}" \
     --with-npth-prefix="${STAGING_DIR}${PREFIX}" \
+    --disable-tests \
     CFLAGS="-std=gnu89"
 
 make -j$(nproc)

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ download_and_extract "gnupg" "$GNUPG_VERSION" "https://gnupg.org/ftp/gcrypt/gnup
 echo ""
 echo "Step 2: Building libgpg-error..."
 cd "libgpg-error-${LIBGPG_ERROR_VERSION}"
-./configure --prefix="$PREFIX" CFLAGS="-std=gnu99"
+./configure --prefix="$PREFIX" --disable-tests
 make -j$(nproc)
 make install DESTDIR="${STAGING_DIR}"
 cd ..
@@ -111,8 +111,7 @@ cd "gnupg-${GNUPG_VERSION}"
     --with-libassuan-prefix="${STAGING_DIR}${PREFIX}" \
     --with-ksba-prefix="${STAGING_DIR}${PREFIX}" \
     --with-npth-prefix="${STAGING_DIR}${PREFIX}" \
-    --disable-tests \
-    CFLAGS="-std=gnu89"
+    --disable-tests
 
 make -j$(nproc)
 make install DESTDIR="${STAGING_DIR}"

--- a/build.sh
+++ b/build.sh
@@ -110,7 +110,8 @@ cd "gnupg-${GNUPG_VERSION}"
     --with-libgcrypt-prefix="${STAGING_DIR}${PREFIX}" \
     --with-libassuan-prefix="${STAGING_DIR}${PREFIX}" \
     --with-ksba-prefix="${STAGING_DIR}${PREFIX}" \
-    --with-npth-prefix="${STAGING_DIR}${PREFIX}"
+    --with-npth-prefix="${STAGING_DIR}${PREFIX}" \
+    CFLAGS="-std=gnu89"
 
 make -j$(nproc)
 make install DESTDIR="${STAGING_DIR}"


### PR DESCRIPTION
- add CFLAGS="-std=gnu99"

libgpg-error-1.49/tests:
warning: format ‘%s’ expects argument of type ‘char *’, but argument 8 has type ‘typeof (nullptr)