### PR TITLE
gpg 2.4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ For more information, see the [GnuPG documentation](https://gnupg.org/documentat
 ## Package Contents
 
 This package includes:
-- GnuPG 2.4.5
-- libgpg-error 1.49
-- libgcrypt 1.10.3
-- libassuan 2.5.7
-- libksba 1.6.6
-- npth 1.7
+- GnuPG
+- libgpg-error
+- libgcrypt
+- libassuan
+- libksba
+- npth
 
 ## Development
 

--- a/apkg/CONTROL/changelog.txt
+++ b/apkg/CONTROL/changelog.txt
@@ -1,15 +1,15 @@
 GnuPG for ASUSTOR NAS - Changelog
 
-Version 2.4.5 (2024-01-15)
+Version 2.4.8 (2024-11-09)
 --------------------------
 * Initial release of GnuPG for ASUSTOR NAS
-* Includes GnuPG 2.4.5 with all core utilities
+* Includes GnuPG 2.4.8 with all core utilities
 * Statically compiled for maximum compatibility
 * Includes dependencies:
-  - libgpg-error 1.49
-  - libgcrypt 1.10.3
-  - libassuan 2.5.7
-  - libksba 1.6.6
-  - npth 1.7
+  - libgpg-error 1.56
+  - libgcrypt 1.11.2
+  - libassuan 3.0.2
+  - libksba 1.6.7
+  - npth 1.8
 * Automated build pipeline via GitHub Actions
 * Command-line tools available after installation

--- a/apkg/CONTROL/config.json
+++ b/apkg/CONTROL/config.json
@@ -45,25 +45,19 @@
       ],
       "/lib": [
         "libassuan.so",
-        "libassuan.so.0",
-        "libassuan.so.0.8.7",
         "libassuan.so.9",
         "libassuan.so.9.0.2",
         "libgcrypt.so",
         "libgcrypt.so.20",
-        "libgcrypt.so.20.4.3",
         "libgcrypt.so.20.6.0",
         "libgpg-error.so",
         "libgpg-error.so.0",
-        "libgpg-error.so.0.36.0",
         "libgpg-error.so.0.40.0",
         "libksba.so",
         "libksba.so.8",
-        "libksba.so.8.14.6",
         "libksba.so.8.14.7",
         "libnpth.so",
         "libnpth.so.0",
-        "libnpth.so.0.2.0",
         "libnpth.so.0.3.0"
       ]
     }

--- a/apkg/CONTROL/config.json
+++ b/apkg/CONTROL/config.json
@@ -2,7 +2,7 @@
   "general": {
     "package": "gnupg",
     "name": "GnuPG",
-    "version": "2.4.5",
+    "version": "2.4.8",
     "depends": [],
     "conflicts": [],
     "developer": "GnuPG Project",
@@ -47,18 +47,24 @@
         "libassuan.so",
         "libassuan.so.0",
         "libassuan.so.0.8.7",
+        "libassuan.so.9",
+        "libassuan.so.9.0.2",
         "libgcrypt.so",
         "libgcrypt.so.20",
         "libgcrypt.so.20.4.3",
+        "libgcrypt.so.20.6.0",
         "libgpg-error.so",
         "libgpg-error.so.0",
         "libgpg-error.so.0.36.0",
+        "libgpg-error.so.0.40.0",
         "libksba.so",
         "libksba.so.8",
         "libksba.so.8.14.6",
+        "libksba.so.8.14.7",
         "libnpth.so",
         "libnpth.so.0",
-        "libnpth.so.0.2.0"
+        "libnpth.so.0.2.0",
+        "libnpth.so.0.3.0"
       ]
     }
   }

--- a/build.sh
+++ b/build.sh
@@ -4,12 +4,12 @@ set -e
 # Build script for GnuPG and dependencies for ASUSTOR NAS
 # This script downloads, compiles, and packages GnuPG
 
-GNUPG_VERSION="2.4.5"
-LIBGPG_ERROR_VERSION="1.49"
-LIBGCRYPT_VERSION="1.10.3"
-LIBASSUAN_VERSION="2.5.7"
-LIBKSBA_VERSION="1.6.6"
-NPTH_VERSION="1.7"
+GNUPG_VERSION="2.4.8"
+LIBGPG_ERROR_VERSION="1.56"
+LIBGCRYPT_VERSION="1.11.2"
+LIBASSUAN_VERSION="3.0.2"
+LIBKSBA_VERSION="1.6.7"
+NPTH_VERSION="1.8"
 
 # Installation prefix
 PREFIX="/usr/local/gnupg"


### PR DESCRIPTION
fixes runtime error due to incorrect library versions
update all libs to latest versions